### PR TITLE
[codex] Guard Pulse adapter initialization before open

### DIFF
--- a/evm/scripts/deploy-local-eth.js
+++ b/evm/scripts/deploy-local-eth.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import hre from "hardhat";
 
-const START_DELAY_SEC = 0n;
+const START_DELAY_SEC = 60n;
 const K = 600n;
 const GENESIS_PRICE = 1_000n;
 const GENESIS_FLOOR = 900n;
@@ -12,16 +12,25 @@ const FIRST_ID = 10_000n;
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 
+async function resolveOpenTime(provider) {
+  const latestBlock = await provider.getBlock("latest");
+  if (!latestBlock) {
+    throw new Error("Failed to read latest block for openTime");
+  }
+  return BigInt(latestBlock.timestamp) + START_DELAY_SEC;
+}
+
 async function main() {
   const conn = await hre.network.connect();
   const { ethers } = conn;
 
   const [deployer, , treasury] = await ethers.getSigners();
   const networkInfo = await ethers.provider.getNetwork();
+  const openTime = await resolveOpenTime(ethers.provider);
 
   const Auction = await ethers.getContractFactory("PulseAuction", deployer);
   const auction = await Auction.deploy(
-    START_DELAY_SEC,
+    openTime,
     K,
     GENESIS_PRICE,
     GENESIS_FLOOR,
@@ -37,6 +46,12 @@ async function main() {
   await adapter.waitForDeployment();
 
   await (await auction.initializeMintAdapter(await adapter.getAddress())).wait();
+  const latestAfterInit = BigInt((await ethers.provider.getBlock("latest")).timestamp);
+  if (latestAfterInit >= openTime) {
+    throw new Error(
+      `UNQUALIFIED_DEPLOYMENT: adapter initialized after openTime latestBlockTs=${latestAfterInit.toString()} openTime=${openTime.toString()}`
+    );
+  }
 
   const deployment = {
     network: conn.networkName,
@@ -49,6 +64,7 @@ async function main() {
       stubAdapter: await adapter.getAddress()
     },
     config: {
+      openTime: openTime.toString(),
       startDelaySec: START_DELAY_SEC.toString(),
       k: K.toString(),
       genesisPrice: GENESIS_PRICE.toString(),

--- a/evm/src/PulseAuction.sol
+++ b/evm/src/PulseAuction.sol
@@ -165,6 +165,7 @@ contract PulseAuction is IPulseAuction {
     /// @notice One-time initializer for mint adapter when constructor used zero address.
     function initializeMintAdapter(address adapter) external override {
         require(msg.sender == deployer, "ONLY_DEPLOYER");
+        require(uint64(block.timestamp) < openTime, "AUCTION_ALREADY_OPEN");
         require(mintAdapter == address(0), "ADAPTER_ALREADY_SET");
         require(adapter != address(0), "INVALID_ADAPTER");
         require(adapter.code.length > 0, "INVALID_ADAPTER");

--- a/evm/src/PulseAuction.sol
+++ b/evm/src/PulseAuction.sol
@@ -31,6 +31,7 @@ contract PulseAuction is IPulseAuction {
         uint64 nextAnchorA,
         uint256 nextFloorB
     );
+    event LaunchConfigured(uint64 indexed openTime, uint64 deployedAt);
 
     // ------------- STORAGE -------------
 
@@ -70,7 +71,7 @@ contract PulseAuction is IPulseAuction {
     // ------------- CONSTRUCTOR -------------
 
     constructor(
-        uint64 startDelaySec,
+        uint64 openTime_,
         uint256 k,
         uint256 _genesisPrice,
         uint256 _genesisFloor,
@@ -89,7 +90,8 @@ contract PulseAuction is IPulseAuction {
         }
 
         uint64 nowTs = uint64(block.timestamp);
-        uint64 _openTime = nowTs + startDelaySec;
+        require(openTime_ >= nowTs, "OPEN_TIME_IN_PAST");
+        uint64 _openTime = openTime_;
         uint64 initialAnchorA = _calculateAnchorTime(_genesisPrice, _genesisFloor, k, _openTime);
 
         openTime = _openTime;
@@ -106,6 +108,8 @@ contract PulseAuction is IPulseAuction {
         paymentToken = _paymentToken;
         treasury = _treasury;
         mintAdapter = _mintAdapter;
+
+        emit LaunchConfigured(_openTime, nowTs);
     }
 
     // ------------- VIEW -------------

--- a/evm/test/helpers/fixtures.js
+++ b/evm/test/helpers/fixtures.js
@@ -6,6 +6,18 @@ import {
   PTS
 } from "./constants.js";
 
+const MIN_ADAPTER_INIT_LEAD_SEC = 60n;
+
+async function resolveOpenTime(ethers, startDelaySec) {
+  const latest = await ethers.provider.getBlock("latest");
+  const latestTs = BigInt(latest.timestamp);
+  const requestedDelay = BigInt(startDelaySec);
+  const setupDelay = requestedDelay > MIN_ADAPTER_INIT_LEAD_SEC
+    ? requestedDelay
+    : MIN_ADAPTER_INIT_LEAD_SEC;
+  return latestTs + setupDelay;
+}
+
 export async function deployERC20Env(ethers, { startDelaySec = 0n } = {}) {
   const [deployer, alice, bob, treasury] = await ethers.getSigners();
 
@@ -18,7 +30,7 @@ export async function deployERC20Env(ethers, { startDelaySec = 0n } = {}) {
 
   const Auction = await ethers.getContractFactory("PulseAuction", deployer);
   const auction = await Auction.deploy(
-    startDelaySec,
+    await resolveOpenTime(ethers, startDelaySec),
     K,
     GENESIS_PRICE,
     GENESIS_FLOOR,
@@ -45,7 +57,7 @@ export async function deployETHEnv(ethers, { startDelaySec = 0n } = {}) {
 
   const Auction = await ethers.getContractFactory("PulseAuction", deployer);
   const auction = await Auction.deploy(
-    startDelaySec,
+    await resolveOpenTime(ethers, startDelaySec),
     K,
     GENESIS_PRICE,
     GENESIS_FLOOR,
@@ -77,7 +89,7 @@ export async function deployEvilEnv(ethers, { startDelaySec = 0n } = {}) {
 
   const Auction = await ethers.getContractFactory("PulseAuction", deployer);
   const auction = await Auction.deploy(
-    startDelaySec,
+    await resolveOpenTime(ethers, startDelaySec),
     K,
     GENESIS_PRICE,
     GENESIS_FLOOR,

--- a/evm/test/pulseAuction.hardening.test.js
+++ b/evm/test/pulseAuction.hardening.test.js
@@ -38,6 +38,11 @@ describe("PulseAuction Hardening (Solidity)", function () {
     ).to.be.revertedWith(reason);
   }
 
+  async function futureOpenTime(delay = 60n) {
+    const latest = await ethers.provider.getBlock("latest");
+    return BigInt(latest.timestamp) + delay;
+  }
+
   it("constructor rejects non-positive genesis gap", async function () {
     const [, , , treasury] = await ethers.getSigners();
 
@@ -110,7 +115,7 @@ describe("PulseAuction Hardening (Solidity)", function () {
     const Auction = await ethers.getContractFactory("PulseAuction", deployer);
 
     const auction = await Auction.deploy(
-      0n,
+      await futureOpenTime(),
       K,
       GENESIS_PRICE,
       GENESIS_FLOOR,
@@ -160,7 +165,7 @@ describe("PulseAuction Hardening (Solidity)", function () {
 
     const Auction = await ethers.getContractFactory("PulseAuction", deployer);
     const auction = await Auction.deploy(
-      0n,
+      await futureOpenTime(),
       K,
       GENESIS_PRICE,
       GENESIS_FLOOR,
@@ -219,7 +224,7 @@ describe("PulseAuction Hardening (Solidity)", function () {
 
     const Auction = await ethers.getContractFactory("PulseAuction", deployer);
     const auction = await Auction.deploy(
-      0n,
+      await futureOpenTime(),
       K,
       GENESIS_PRICE,
       GENESIS_FLOOR,

--- a/evm/test/pulseAuction.safety.test.js
+++ b/evm/test/pulseAuction.safety.test.js
@@ -30,6 +30,11 @@ describe("PulseAuction Safety + Settlement (Solidity)", function () {
     await conn.close();
   });
 
+  async function futureOpenTime(delay = 60n) {
+    const latest = await ethers.provider.getBlock("latest");
+    return BigInt(latest.timestamp) + delay;
+  }
+
   it("reverts when ask is above maxPrice", async function () {
     const { auction, alice } = await deployERC20Env(ethers, { startDelaySec: 50n });
     const openTime = await auction.openTime();
@@ -91,12 +96,12 @@ describe("PulseAuction Safety + Settlement (Solidity)", function () {
     expect(await ethers.provider.getBalance(await auction.getAddress())).to.equal(0n);
   });
 
-  it("requires adapter initialization before bidding and allows one-time deployer init", async function () {
+  it("allows one-time deployer adapter initialization before open", async function () {
     const [deployer, alice, , treasury] = await ethers.getSigners();
 
     const Auction = await ethers.getContractFactory("PulseAuction", deployer);
     const auction = await Auction.deploy(
-      0n,
+      await futureOpenTime(),
       K,
       GENESIS_PRICE,
       GENESIS_FLOOR,
@@ -106,12 +111,6 @@ describe("PulseAuction Safety + Settlement (Solidity)", function () {
       ethers.ZeroAddress
     );
     await auction.waitForDeployment();
-
-    const t1 = (await auction.openTime()) + 1_000n;
-    await setNextBlockTimestamp(provider, t1);
-    await expect(auction.connect(alice).bid(LARGE_MAX_PRICE, { value: GENESIS_PRICE })).to.be.revertedWith(
-      "ADAPTER_NOT_SET"
-    );
 
     const Adapter = await ethers.getContractFactory("StubAdapter", deployer);
     const adapter = await Adapter.deploy(await auction.getAddress(), FIRST_ID);
@@ -126,6 +125,33 @@ describe("PulseAuction Safety + Settlement (Solidity)", function () {
     await expect(
       auction.initializeMintAdapter(await adapter.getAddress())
     ).to.be.revertedWith("ADAPTER_ALREADY_SET");
+  });
+
+  it("requires adapter initialization before bidding and rejects initialization after open", async function () {
+    const [deployer, , , treasury] = await ethers.getSigners();
+
+    const Auction = await ethers.getContractFactory("PulseAuction", deployer);
+    const auction = await Auction.deploy(
+      await futureOpenTime(),
+      K,
+      GENESIS_PRICE,
+      GENESIS_FLOOR,
+      PTS,
+      ethers.ZeroAddress,
+      treasury.address,
+      ethers.ZeroAddress
+    );
+    await auction.waitForDeployment();
+
+    const openTime = await auction.openTime();
+    await setNextBlockTimestamp(provider, openTime);
+    await expect(auction.bid(LARGE_MAX_PRICE, { value: GENESIS_PRICE })).to.be.revertedWith("ADAPTER_NOT_SET");
+
+    const Adapter = await ethers.getContractFactory("StubAdapter", deployer);
+    const adapter = await Adapter.deploy(await auction.getAddress(), FIRST_ID);
+    await adapter.waitForDeployment();
+
+    await expect(auction.initializeMintAdapter(await adapter.getAddress())).to.be.revertedWith("AUCTION_ALREADY_OPEN");
   });
 
   it("enforces one-bid-per-block", async function () {
@@ -144,6 +170,7 @@ describe("PulseAuction Safety + Settlement (Solidity)", function () {
       )
     ).wait();
 
+    await setNextBlockTimestamp(provider, await auction.openTime());
     await expect(
       batcher.bidTwice(await auction.getAddress(), GENESIS_PRICE, GENESIS_PRICE)
     ).to.be.revertedWith("ONE_BID_PER_BLOCK");


### PR DESCRIPTION
## Summary
- require initializeMintAdapter before auction open
- update local deploy and test fixtures to initialize adapters before open
- add coverage for after-open initialization rejection

## Validation
- npm run compile
- npm test